### PR TITLE
fix: addAttribute(): Passing null to parameter 2 ($value) of type str…

### DIFF
--- a/src/workflows.php
+++ b/src/workflows.php
@@ -184,17 +184,25 @@ class Workflows {
 			$c_keys = array_keys( $b );						// Grab all the keys for that item
 			foreach( $c_keys as $key ):						// For each of those keys
 				if ( $key == 'uid' ):
-					$c->addAttribute( 'uid', $b[$key] );
+					if ( !is_null($b[$key]) ):
+						$c->addAttribute( 'uid', $b[$key] );
+					endif;
 				elseif ( $key == 'arg' ):
-					$c->addAttribute( 'arg', $b[$key] );
+					if ( !is_null($b[$key]) ):
+						$c->addAttribute( 'arg', $b[$key] );
+					endif;
 				elseif ( $key == 'type' ):
-					$c->addAttribute( 'type', $b[$key] );
+					if ( !is_null($b[$key]) ):
+						$c->addAttribute( 'type', $b[$key] );
+					endif;
 				elseif ( $key == 'valid' ):
 					if ( $b[$key] == 'yes' || $b[$key] == 'no' ):
 						$c->addAttribute( 'valid', $b[$key] );
 					endif;
 				elseif ( $key == 'autocomplete' ):
-					$c->addAttribute( 'autocomplete', $b[$key] );
+					if ( !is_null($b[$key]) ):
+						$c->addAttribute( 'autocomplete', $b[$key] );
+					endif;
 				elseif ( $key == 'icon' ):
 					if ( substr( $b[$key], 0, 9 ) == 'fileicon:' ):
 						$val = substr( $b[$key], 9 );


### PR DESCRIPTION
 Deprecated: SimpleXMLElement::addAttribute(): Passing null to parameter #2 ($value) of type string is deprecated in /Users/xx/Dropbox/Alfred/Alfred.alfredpreferences/workflows/user.workflow.F3720511-06CF-4BEE-9398-F9E4C081B255/workflows.php