### PR TITLE
In Alfred 3 the workflow wasn't working due to references to alfred 2

### DIFF
--- a/src/workflows.php
+++ b/src/workflows.php
@@ -38,8 +38,8 @@ class Workflows {
 			$this->bundle = $bundleid;
 		endif;
 
-		$this->cache = $this->home. "/Library/Caches/com.runningwithcrayons.Alfred-2/Workflow Data/".$this->bundle;
-		$this->data  = $this->home. "/Library/Application Support/Alfred 2/Workflow Data/".$this->bundle;
+		$this->cache = $this->home. "/Library/Caches/com.runningwithcrayons.Alfred/Workflow Data/".$this->bundle;
+		$this->data  = $this->home. "/Library/Application Support/Alfred/Workflow Data/".$this->bundle;
 
 		if ( !file_exists( $this->cache ) ):
 			exec("mkdir '".$this->cache."'");
@@ -194,7 +194,7 @@ class Workflows {
 						$c->addAttribute( 'valid', $b[$key] );
 					endif;
 				elseif ( $key == 'autocomplete' ):
-					$c->addAttribute( 'autocomplete', $b[$key] );
+					$c->addAttribute( 'autocomplete', $b[$key] ?? '' );
 				elseif ( $key == 'icon' ):
 					if ( substr( $b[$key], 0, 9 ) == 'fileicon:' ):
 						$val = substr( $b[$key], 9 );


### PR DESCRIPTION
I wasn't able to encode and decode using alfred 3, removing the mention of alfred 2 in the workflows.php fixed the issue. 

There is still the issue with macos Monterey where you have to allows the normalise app for decoding but that is a macos issue which cannot be fixed in the workflow.